### PR TITLE
Fix typo in _oasis:Copyrights

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -5,7 +5,7 @@ Name:             typehashlib
 Version:          109.15.00
 Synopsis:         Syntax extension for deriving "typehash" functions automatically.
 Authors:          Jane Street Group, LLC <opensource@janestreet.com>
-Copyrights:       (C) 2009-2013 Jane Street Group, LLC <opensource@janestreet.com>
+Copyrights:       (C) 2009-2013 Jane Street Group LLC <opensource@janestreet.com>
 Maintainers:      Jane Street Group, LLC <opensource@janestreet.com>
 License:          Apache-2.0
 LicenseFile:      LICENSE.txt


### PR DESCRIPTION
Remove comma to fix syntax error:
E: Copyright must follow the convention '(C) 2008-2009 J.R. Hacker', here it is 'LLC opensource@janestreet.com'

Signed-off-by: Olaf Hering olaf@aepfle.de
